### PR TITLE
browser support

### DIFF
--- a/examples/slicer/index.html
+++ b/examples/slicer/index.html
@@ -1,0 +1,15 @@
+
+<!DOCTYPE HTML>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>B E E F Y</title>
+    <style type="text/css">
+      html, body { width: 100%; height: 100%;}
+    </style>
+</head>
+<body>
+    
+    <script src="/test.js" type="text/javascript"></script>
+</body>
+</html>

--- a/examples/slicer/package.json
+++ b/examples/slicer/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "canvas": "1.1.0"
+    "canvas": "~1.1.0"
   },
   "repository": "",
   "author": "Michael Nutt",

--- a/examples/slicer/slicer.js
+++ b/examples/slicer/slicer.js
@@ -1,8 +1,7 @@
 var fs = require('fs')
 var Parser = require('../..').Parser;
-var Canvas = require('canvas');
-var PixelArray = require('canvas/lib/bindings').CanvasPixelArray;
-var ImageData = require('canvas/lib/bindings').ImageData;
+var ndarray = require('ndarray')
+var savePixels = require('save-pixels')
 
 if(!process.argv[3]) {
   console.log("Usage: node slicer.js FILE_NAME.psd OUT_DIRECTORY");
@@ -17,7 +16,7 @@ psd.parse();
 var height = psd.header.rows;
 var width = psd.header.columns;
 
-var pixels = new PixelArray(width, height);
+var pixels = ndarray(new Uint8Array(height * width * 3), [height, width, 3])
 var channels = psd.imageData.image.channel;
 
 var color = psd.imageData.createColor(psd.header, psd.colorModeData);
@@ -26,55 +25,48 @@ var x, y, index;
 for(y = 0; y < height; ++y) {
   for(x = 0; x < width; ++x) {
     index = (y * width + x);
-    pixels[index * 4    ] = color[0][index];
-    pixels[index * 4 + 1] = color[1][index];
-    pixels[index * 4 + 2] = color[2][index];
-    pixels[index * 4 + 3] = 255;
+    pixels.set(y, x, 0, color[0][index])
+    pixels.set(y, x, 1, color[1][index])
+    pixels.set(y, x, 2, color[2][index])
   }
 }
 
-var canvas = new Canvas(width, height);
-var ctx = canvas.getContext('2d');
-
-var imageData = new ImageData(pixels);
-ctx.putImageData(imageData, 0, 0);
-
-canvas.pngStream().pipe(fs.createWriteStream(process.argv[3] + '/whole.png'));
-
-var resources = {};
-var imageResources = psd.imageResources.imageResources;
-for(var i = 0; i < imageResources.length; i++) {
-  resources[imageResources[i].identifier] = imageResources[i];
-}
-
-console.log(resources['1050'].toObject());
-var slices = resources['1050'].toObject().slices;
-
-for(var i = 0; i < slices.length; i++) {
-  (function(slice) {
-    var slice = slices[i];
-
-    slice.id = slice.sliceID;
-    slice.width = slice.bounds.Rght - slice.bounds.Left;
-    slice.height = slice.bounds.Btom - slice.bounds.Top;
-
-    if(slice.id == 0) { return; } // slice 0 is auto-generated, and is whole canvas
-
-    var sliceCanvas = new Canvas(slice.width, slice.height);
-    var sliceCtx = sliceCanvas.getContext('2d');
-    sliceCtx.putImageData(ctx.getImageData(slice.bounds.Left,
-                                           slice.bounds.Top,
-                                           slice.width,
-                                           slice.height), 0, 0);
-
-    console.log("slicing " + slice.id + " into " + [slice.bounds.Left,
-                                                    slice.bounds.Top,
-                                                    slice.width,
-                                                    slice.height].join(', '));
-
-    var out = fs.createWriteStream(process.argv[3] + '/' + slice.id + '.png');
-    sliceCanvas.pngStream().pipe(out);
-  })(slices[i]);
-}
+savePixels(pixels, "png").pipe(fs.createWriteStream(process.argv[3] + '/whole.png'));
+// 
+// var resources = {};
+// var imageResources = psd.imageResources.imageResources;
+// for(var i = 0; i < imageResources.length; i++) {
+//   resources[imageResources[i].identifier] = imageResources[i];
+// }
+// 
+// console.log(resources['1050'].toObject());
+// var slices = resources['1050'].toObject().slices;
+// 
+// for(var i = 0; i < slices.length; i++) {
+//   (function(slice) {
+//     var slice = slices[i];
+// 
+//     slice.id = slice.sliceID;
+//     slice.width = slice.bounds.Rght - slice.bounds.Left;
+//     slice.height = slice.bounds.Btom - slice.bounds.Top;
+// 
+//     if(slice.id == 0) { return; } // slice 0 is auto-generated, and is whole canvas
+// 
+//     var sliceCanvas = new Canvas(slice.width, slice.height);
+//     var sliceCtx = sliceCanvas.getContext('2d');
+//     sliceCtx.putImageData(ctx.getImageData(slice.bounds.Left,
+//                                            slice.bounds.Top,
+//                                            slice.width,
+//                                            slice.height), 0, 0);
+// 
+//     console.log("slicing " + slice.id + " into " + [slice.bounds.Left,
+//                                                     slice.bounds.Top,
+//                                                     slice.width,
+//                                                     slice.height].join(', '));
+// 
+//     var out = fs.createWriteStream(process.argv[3] + '/' + slice.id + '.png');
+//     sliceCanvas.pngStream().pipe(out);
+//   })(slices[i]);
+// }
 
 //console.log(JSON.stringify(slices, null, 2));

--- a/examples/slicer/test.js
+++ b/examples/slicer/test.js
@@ -1,0 +1,61 @@
+var global = window
+var Parser = require('psd').Parser
+var ndarray = require('ndarray')
+var savePixels = require('save-pixels')
+var concat = require('concat-stream')
+
+var body = document.body
+
+function noop(event) {
+  event.preventDefault()
+  event.stopPropagation()
+  return false
+}
+
+['dragenter',
+ 'dragleave',
+ 'dragexit',
+ 'dragover'
+].forEach(function (eventType) {
+   body.addEventListener(eventType, noop)
+})
+
+body.addEventListener('drop', function (event) {
+  event.stopPropagation()
+  event.preventDefault()
+
+  var firstFile = event.dataTransfer.files[0]
+  var reader = new FileReader();
+  reader.onload = function(e) {
+    var canvas = convertPSD(e.target.result)
+    body.appendChild(canvas)
+  }
+  reader.readAsArrayBuffer(firstFile)
+
+  return false
+})
+
+function convertPSD(data) {
+  var psd = new Parser(data);
+  psd.parse();
+
+  var height = psd.header.rows;
+  var width = psd.header.columns;
+
+  var pixels = ndarray(new Uint8Array(height * width * 3), [height, width, 3])
+  var channels = psd.imageData.image.channel;
+
+  var color = psd.imageData.createColor(psd.header, psd.colorModeData);
+
+  var x, y, index;
+  for(y = 0; y < height; ++y) {
+    for(x = 0; x < width; ++x) {
+      index = (y * width + x);
+      pixels.set(y, x, 0, color[0][index])
+      pixels.set(y, x, 1, color[1][index])
+      pixels.set(y, x, 2, color[2][index])
+    }
+  }
+
+  return savePixels(pixels, "canvas")
+}

--- a/src/AdditionalLayerInfo.js
+++ b/src/AdditionalLayerInfo.js
@@ -1,5 +1,3 @@
-var fs = require('fs');
-
 /**
  * @constructor
  */
@@ -58,7 +56,26 @@ module.exports = AdditionalLayerInfo;
 
 require('./AdditionalLayerInfo/EffectsLayer');
 
-var layers = fs.readdirSync(__dirname + "/AdditionalLayerInfo");
-for(var i = 0; i < layers.length; i++) {
-  require('./AdditionalLayerInfo/' + layers[i]);
-}
+require('./AdditionalLayerInfo/Patt.js')
+require('./AdditionalLayerInfo/SoLd.js')
+require('./AdditionalLayerInfo/fxrp.js')
+require('./AdditionalLayerInfo/knko.js')
+require('./AdditionalLayerInfo/lnsr.js')
+require('./AdditionalLayerInfo/lspf.js')
+require('./AdditionalLayerInfo/lyvr.js')
+require('./AdditionalLayerInfo/EffectsLayer.js')
+require('./AdditionalLayerInfo/PlLd.js')
+require('./AdditionalLayerInfo/TySh.js')
+require('./AdditionalLayerInfo/iOpa.js')
+require('./AdditionalLayerInfo/lclr.js')
+require('./AdditionalLayerInfo/lrFX.js')
+require('./AdditionalLayerInfo/luni.js')
+require('./AdditionalLayerInfo/shmd.js')
+require('./AdditionalLayerInfo/GdFl.js')
+require('./AdditionalLayerInfo/SoCo.js')
+require('./AdditionalLayerInfo/clbl.js')
+require('./AdditionalLayerInfo/infx.js')
+require('./AdditionalLayerInfo/lfx2.js')
+require('./AdditionalLayerInfo/lsct.js')
+require('./AdditionalLayerInfo/lyid.js')
+require('./AdditionalLayerInfo/vmsk.js')

--- a/src/AdditionalLayerInfo/EffectsLayer.js
+++ b/src/AdditionalLayerInfo/EffectsLayer.js
@@ -1,9 +1,11 @@
-var fs = require('fs');
 var AdditionalLayerInfo = require('../AdditionalLayerInfo');
 
 AdditionalLayerInfo.EffectsLayer = {};
 
-var effectsLayers = fs.readdirSync(__dirname + "/EffectsLayer");
-for(var i = 0; i < effectsLayers.length; i++) {
-  require('./EffectsLayer/' + effectsLayers[i]);
-}
+require('./EffectsLayer/bevl.js')
+require('./EffectsLayer/cmnS.js')
+require('./EffectsLayer/dsdw.js')
+require('./EffectsLayer/iglw.js')
+require('./EffectsLayer/isdw.js')
+require('./EffectsLayer/oglw.js')
+require('./EffectsLayer/sofi.js')

--- a/src/Descriptor.js
+++ b/src/Descriptor.js
@@ -1,4 +1,3 @@
-var fs = require('fs');
 
 /**
  * @constructor
@@ -79,8 +78,21 @@ Descriptor.prototype.toObject = function() {
 
 module.exports = Descriptor;
 
-
-var descriptors = fs.readdirSync(__dirname + "/Descriptor");
-for(var i = 0; i < descriptors.length; i++) {
-  require('./Descriptor/' + descriptors[i]);
-}
+require('./Descriptor/GlbC.js')
+require('./Descriptor/GlbO.js')
+require('./Descriptor/ObAr.js')
+require('./Descriptor/Objc.js')
+require('./Descriptor/TEXT.js')
+require('./Descriptor/UnFl.js')
+require('./Descriptor/UntF.js')
+require('./Descriptor/VlLs.js')
+require('./Descriptor/alis.js')
+require('./Descriptor/bool.js')
+require('./Descriptor/doub.js')
+require('./Descriptor/enum.js')
+require('./Descriptor/long.js')
+require('./Descriptor/obj.js')
+require('./Descriptor/prop.js')
+require('./Descriptor/rele.js')
+require('./Descriptor/tdta.js')
+require('./Descriptor/type.js')

--- a/src/ImageResourceBlock.js
+++ b/src/ImageResourceBlock.js
@@ -1,6 +1,4 @@
-var fs = require('fs');
 var StreamReader = require('./StreamReader');
-
 /**
  * @constructor
  */
@@ -58,7 +56,4 @@ ImageResourceBlock.prototype.toObject = function() {
 
 module.exports = ImageResourceBlock;
 
-var blocks = fs.readdirSync(__dirname + "/ImageResourceBlocks");
-for(var i = 0; i < blocks.length; i++) {
-  require('./ImageResourceBlocks/' + blocks[i]);
-}
+require('./ImageResourceBlocks/1050.js')


### PR DESCRIPTION
this isn't done yet, but i'm opening this to keep track of progress

todo for browser support:
- [ ] use https://npmjs.org/package/bops everywhere Buffer/Typed Arrays are used instead
- [ ] move examples/slicer/test.js into it's own module (probably called `psd-preview`)
- [ ] write a simple little integration test that can be easily run in both node + browsers (e.g. via `npm test` or `npm start` to start a browser test server) 
