### PR TITLE
get bounds by key

### DIFF
--- a/src/ImageResourceBlock.js
+++ b/src/ImageResourceBlock.js
@@ -139,7 +139,13 @@ ImageResourceBlock['1050'].prototype.parse = function(stream) {
     var sliceDataArray = this.descriptor.item[2].data.item;
     this.slices = sliceDataArray.map(function(sliceData) {
       var attrs = sliceData.data.value.item;
-      var bounds = attrs[4].data.value.item;
+      for (var i=0; i<attrs.length; i++) {
+        if (attrs[i].key === "bounds") {
+          var bounds = attrs[i].data.value.item;
+          break;
+        }
+      }
+
       return {
         origin: attrs[2].data.enum,
         bounds: {


### PR DESCRIPTION
specifically in https://github.com/movableink/psd.js/blob/master/src/ImageResourceBlock.js#L142

experienced an issue where a psd was uploaded and returned an error because the `bounds` weren't at the 4th index of the attrs array.

Instead, set bounds to the object that has the `key: 'bounds'`